### PR TITLE
Prebuild deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,4 @@ const accounts = await d365Client.retrieveMultipleRecords<Account>(
 ## Credits
 
 Thanks to [HSO](https://github.com/hso-nn/d365-cli) for query options.
+Thanks to Microsoft for persistence cache.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@primno/d365-client",
-  "version": "0.5.0",
+  "version": "0.5.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@primno/d365-client",
-      "version": "0.5.0",
+      "version": "0.5.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^1.14.3",
-        "@azure/msal-node-extensions": "^1.0.0-alpha.26",
         "@tediousjs/connection-string": "^0.4.1",
         "axios": "^1.1.3",
         "axios-ntlm": "^1.3.0",
         "axios-oauth-client": "^1.5.0",
         "axios-token-interceptor": "^0.2.0",
+        "keytar": "^7.9.0",
         "uri-js": "^4.4.1",
         "win-ca": "^3.5.0"
       },
@@ -53,20 +53,6 @@
       },
       "engines": {
         "node": "10 || 12 || 14 || 16 || 18"
-      }
-    },
-    "node_modules/@azure/msal-node-extensions": {
-      "version": "1.0.0-alpha.26",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node-extensions/-/msal-node-extensions-1.0.0-alpha.26.tgz",
-      "integrity": "sha512-vrseohp9pqVHxunN0J0irl/shADorGk6aAbuxOYEOPs0fN5zmLQE/53oXOr2Gl0ur7ArdoIXqcAJgVi34BtCHw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@azure/msal-common": "^8.0.0",
-        "keytar": "^7.8.0",
-        "node-addon-api": "5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2000,11 +1986,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/node-addon-api": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
-      "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
-    },
     "node_modules/node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -2900,16 +2881,6 @@
         "@azure/msal-common": "^8.0.0",
         "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
-      }
-    },
-    "@azure/msal-node-extensions": {
-      "version": "1.0.0-alpha.26",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node-extensions/-/msal-node-extensions-1.0.0-alpha.26.tgz",
-      "integrity": "sha512-vrseohp9pqVHxunN0J0irl/shADorGk6aAbuxOYEOPs0fN5zmLQE/53oXOr2Gl0ur7ArdoIXqcAJgVi34BtCHw==",
-      "requires": {
-        "@azure/msal-common": "^8.0.0",
-        "keytar": "^7.8.0",
-        "node-addon-api": "5.0.0"
       }
     },
     "@babel/code-frame": {
@@ -4363,11 +4334,6 @@
           }
         }
       }
-    },
-    "node-addon-api": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
-      "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
     },
     "node-forge": {
       "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^1.14.3",
+        "@primno/dpapi": "^1.0.0-alpha.0",
         "@tediousjs/connection-string": "^0.4.1",
         "axios": "^1.1.3",
         "axios-ntlm": "^1.3.0",
@@ -32,6 +33,25 @@
         "ts-node": "^10.9.1",
         "tslib": "^2.4.1",
         "typescript": "^4.9.3"
+      }
+    },
+    "../dpapi": {
+      "name": "@primno/dpapi",
+      "version": "1.0.0-alpha.0",
+      "extraneous": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-gyp-build": "^4.5.0"
+      },
+      "devDependencies": {
+        "@types/node": "^18.11.9",
+        "node-addon-api": "^5.0.0",
+        "node-gyp": "^9.3.0",
+        "prebuildify": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@azure/msal-common": {
@@ -330,6 +350,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@primno/dpapi": {
+      "version": "1.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@primno/dpapi/-/dpapi-1.0.0-alpha.0.tgz",
+      "integrity": "sha512-yEPLirB/iOreHG+/Bs+wTNwnJOcXIO7ujVP5UaS7KrwmNHwWU+EertMD/pX649J9lEl6HU9oHZKVJyIJogf8Pg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
@@ -1994,6 +2026,16 @@
         "node": ">= 6.13.0"
       }
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
@@ -3101,6 +3143,14 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@primno/dpapi": {
+      "version": "1.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@primno/dpapi/-/dpapi-1.0.0-alpha.0.tgz",
+      "integrity": "sha512-yEPLirB/iOreHG+/Bs+wTNwnJOcXIO7ujVP5UaS7KrwmNHwWU+EertMD/pX649J9lEl6HU9oHZKVJyIJogf8Pg==",
+      "requires": {
+        "node-gyp-build": "^4.5.0"
       }
     },
     "@rollup/plugin-commonjs": {
@@ -4339,6 +4389,11 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
+    },
+    "node-gyp-build": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg=="
     },
     "object-inspect": {
       "version": "1.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primno/d365-client",
-  "version": "1.0.0-beta.0",
+  "version": "0.5.0-beta.0",
   "description": "Dynamics 365 Client for Node.JS",
   "repository": "github:primno/d365-client",
   "main": "dist/d365-client.cjs.js",
@@ -21,12 +21,12 @@
   "license": "MIT",
   "dependencies": {
     "@azure/msal-node": "^1.14.3",
-    "@azure/msal-node-extensions": "^1.0.0-alpha.26",
     "@tediousjs/connection-string": "^0.4.1",
     "axios": "^1.1.3",
     "axios-ntlm": "^1.3.0",
     "axios-oauth-client": "^1.5.0",
     "axios-token-interceptor": "^0.2.0",
+    "keytar": "^7.9.0",
     "uri-js": "^4.4.1",
     "win-ca": "^3.5.0"
   },
@@ -52,5 +52,11 @@
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
-  }
+  },
+  "keywords": [
+    "dynamics",
+    "d365",
+    "webapi",
+    "dataverse"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@azure/msal-node": "^1.14.3",
+    "@primno/dpapi": "^1.0.0-alpha.0",
     "@tediousjs/connection-string": "^0.4.1",
     "axios": "^1.1.3",
     "axios-ntlm": "^1.3.0",

--- a/src/axios-d365/auth/oauth/msal/extensions/Dpapi.ts
+++ b/src/axios-d365/auth/oauth/msal/extensions/Dpapi.ts
@@ -1,0 +1,12 @@
+// /*
+//  * Copyright (c) Microsoft Corporation. All rights reserved.
+//  * Licensed under the MIT License.
+//  */
+
+// export interface DpapiBindings{
+//     protectData(dataToEncrypt: Uint8Array, optionalEntropy: Uint8Array, scope: string): Uint8Array
+//     unprotectData(encryptData: Uint8Array, optionalEntropy: Uint8Array, scope: string): Uint8Array
+// }
+// /* eslint-disable-next-line @typescript-eslint/no-var-requires, no-var, import/no-commonjs */
+// export var Dpapi: DpapiBindings = require("../build/Release/dpapi.node");
+// export default Dpapi;

--- a/src/axios-d365/auth/oauth/msal/extensions/README.md
+++ b/src/axios-d365/auth/oauth/msal/extensions/README.md
@@ -1,0 +1,6 @@
+# Extension
+
+Modified version of @azure/msal-node-extensions to avoid dependency on python and visual c++.
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.

--- a/src/axios-d365/auth/oauth/msal/extensions/error/PersistenceError.ts
+++ b/src/axios-d365/auth/oauth/msal/extensions/error/PersistenceError.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Error thrown when trying to write MSAL cache to persistence.
+ */
+export class PersistenceError extends Error {
+
+    // Short string denoting error
+    errorCode: string;
+    // Detailed description of error
+    errorMessage: string;
+
+    constructor(errorCode: string, errorMessage: string) {
+        const errorString = errorMessage ? `${errorCode}: ${errorMessage}` : errorCode;
+        super(errorString);
+        Object.setPrototypeOf(this, PersistenceError.prototype);
+
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.name = "PersistenceError";
+    }
+
+    /**
+     * Error thrown when trying to access the file system.
+     */
+    static createFileSystemError(errorCode: string, errorMessage: string): PersistenceError {
+        return new PersistenceError(errorCode, errorMessage);
+    }
+
+    /**
+     * Error thrown when trying to write, load, or delete data from secret service on linux.
+     * Libsecret is used to access secret service.
+     */
+    static createLibSecretError(errorMessage: string): PersistenceError {
+        return new PersistenceError("GnomeKeyringError", errorMessage);
+    }
+
+    /**
+     * Error thrown when trying to write, load, or delete data from keychain on macOs.
+     */
+    static createKeychainPersistenceError(errorMessage: string): PersistenceError {
+        return new PersistenceError("KeychainError", errorMessage);
+    }
+
+    /**
+     * Error thrown when trying to encrypt or decrypt data using DPAPI on Windows.
+     */
+    static createFilePersistenceWithDPAPIError(errorMessage: string): PersistenceError {
+        return new PersistenceError("DPAPIEncryptedFileError", errorMessage);
+    }
+
+    /**
+     * Error thrown when using the cross platform lock.
+     */
+    static createCrossPlatformLockError(errorMessage: string): PersistenceError {
+        return new PersistenceError("CrossPlatformLockError", errorMessage);
+    }
+
+    /**
+     * Throw cache persistence error
+     * 
+     * @param errorMessage string
+     * @returns PersistenceError
+     */
+    static createCachePersistenceError(errorMessage: string): PersistenceError {
+        return new PersistenceError("CachePersistenceError", errorMessage);
+    }
+
+    /**
+     * Throw unsupported error
+     * 
+     * @param errorMessage string
+     * @returns PersistenceError
+     */
+    static createNotSupportedError(errorMessage: string): PersistenceError {
+        return new PersistenceError("NotSupportedError", errorMessage);
+    }
+
+    /**
+     * Throw persistence not verified error
+     * 
+     * @param errorMessage string
+     * @returns PersistenceError
+     */
+    static createPersistenceNotVerifiedError(errorMessage: string): PersistenceError {
+        return new PersistenceError("PersistenceNotVerifiedError", errorMessage);
+    }
+
+    /**
+     * Throw persistence creation validation error
+     * 
+     * @param errorMessage string
+     * @returns PersistenceError
+     */
+    static createPersistenceNotValidatedError(errorMessage: string): PersistenceError {
+        return new PersistenceError("PersistenceNotValidatedError", errorMessage);
+    }
+}

--- a/src/axios-d365/auth/oauth/msal/extensions/index.ts
+++ b/src/axios-d365/auth/oauth/msal/extensions/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { PersistenceCachePlugin } from "./persistence/PersistenceCachePlugin";
+export { FilePersistence } from "./persistence/FilePersistence";
+//export { FilePersistenceWithDataProtection } from "./persistence/FilePersistenceWithDataProtection";
+export { DataProtectionScope } from "./persistence/DataProtectionScope";
+export { KeychainPersistence } from "./persistence/KeychainPersistence";
+export { LibSecretPersistence } from "./persistence/LibSecretPersistence";
+export { IPersistence } from "./persistence/IPersistence";
+export { CrossPlatformLockOptions } from "./lock/CrossPlatformLockOptions";
+export { PersistenceCreator } from "./persistence/PersistenceCreator";
+export { IPersistenceConfiguration } from "./persistence/IPersistenceConfiguration";
+export { Environment } from "./utils/Environment";

--- a/src/axios-d365/auth/oauth/msal/extensions/lock/CrossPlatformLock.ts
+++ b/src/axios-d365/auth/oauth/msal/extensions/lock/CrossPlatformLock.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { promises as fs } from "fs";
+import { pid } from "process";
+import { CrossPlatformLockOptions } from "./CrossPlatformLockOptions";
+import { Constants } from "../utils/Constants";
+import { PersistenceError } from "../error/PersistenceError";
+import { Logger } from "@azure/msal-common";
+
+/**
+ * Cross-process lock that works on all platforms.
+ */
+export class CrossPlatformLock {
+
+    private readonly lockFilePath: string;
+    private lockFileHandle!: fs.FileHandle;
+    private readonly retryNumber: number;
+    private readonly retryDelay: number;
+
+    private logger: Logger;
+
+    constructor(lockFilePath: string, logger: Logger, lockOptions?: CrossPlatformLockOptions) {
+        this.lockFilePath = lockFilePath;
+        this.retryNumber = lockOptions ? lockOptions.retryNumber : 500;
+        this.retryDelay = lockOptions ? lockOptions.retryDelay : 100;
+        this.logger = logger;
+    }
+
+    /**
+     * Locks cache from read or writes by creating file with same path and name as
+     * cache file but with .lockfile extension. If another process has already created
+     * the lockfile, will back off and retry based on configuration settings set by CrossPlatformLockOptions
+     */
+    public async lock(): Promise<void> {
+        for (let tryCount = 0; tryCount < this.retryNumber; tryCount++) {
+            try {
+                this.logger.info(`Pid ${pid} trying to acquire lock`);
+                this.lockFileHandle = await fs.open(this.lockFilePath, "wx+");
+
+                this.logger.info(`Pid ${pid} acquired lock`);
+                await this.lockFileHandle.write(pid.toString());
+                return;
+            } catch (err: any) {
+                if (err.code === Constants.EEXIST_ERROR || err.code === Constants.EPERM_ERROR) {
+                    this.logger.info(err);
+                    await this.sleep(this.retryDelay);
+                } else {
+                    this.logger.error(`${pid} was not able to acquire lock. Ran into error: ${err.message}`);
+                    throw PersistenceError.createCrossPlatformLockError(err.message);
+                }
+            }
+        }
+        this.logger.error(`${pid} was not able to acquire lock. Exceeded amount of retries set in the options`);
+        throw PersistenceError.createCrossPlatformLockError(
+            "Not able to acquire lock. Exceeded amount of retries set in options");
+    }
+
+    /**
+     * unlocks cache file by deleting .lockfile.
+     */
+    public async unlock(): Promise<void> {
+        try {
+            if(this.lockFileHandle){
+                // if we have a file handle to the .lockfile, delete lock file
+                await fs.unlink(this.lockFilePath);
+                await this.lockFileHandle.close();
+                this.logger.info("lockfile deleted");
+            } else {
+                this.logger.warning("lockfile handle does not exist, so lockfile could not be deleted");
+            }
+        } catch (err: any) {
+            if (err.code === Constants.ENOENT_ERROR) {
+                this.logger.info("Tried to unlock but lockfile does not exist");
+            } else {
+                this.logger.error(`${pid} was not able to release lock. Ran into error: ${err.message}`);
+                throw PersistenceError.createCrossPlatformLockError(err.message);
+            }
+        }
+    }
+
+    private sleep(ms: number): Promise<void> {
+        return new Promise((resolve) => {
+            setTimeout(resolve, ms);
+        });
+    }
+}

--- a/src/axios-d365/auth/oauth/msal/extensions/lock/CrossPlatformLockOptions.ts
+++ b/src/axios-d365/auth/oauth/msal/extensions/lock/CrossPlatformLockOptions.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Options for CrossPlatform lock.
+ *
+ * retryNumber: Numbers of times we should try to acquire a lock. Defaults to 500.
+ * retryDelay: Time to wait before trying to retry a lock acquisition. Defaults to 100 ms.
+ */
+export type CrossPlatformLockOptions = {
+    retryNumber: number;
+    retryDelay: number;
+};

--- a/src/axios-d365/auth/oauth/msal/extensions/persistence/BasePersistence.ts
+++ b/src/axios-d365/auth/oauth/msal/extensions/persistence/BasePersistence.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { PersistenceError } from "../error/PersistenceError";
+import { Constants } from "../utils/Constants";
+import { IPersistence } from "./IPersistence";
+
+export abstract class BasePersistence {
+    public abstract createForPersistenceValidation(): Promise<IPersistence>; 
+
+    public async verifyPersistence(): Promise<boolean> {
+        // We are using a different location for the test to avoid overriding the functional cache
+        const persistenceValidator = await this.createForPersistenceValidation();
+
+        try {
+            await persistenceValidator.save(Constants.PERSISTENCE_TEST_DATA);
+
+            const retrievedDummyData = await persistenceValidator.load();
+
+            if (!retrievedDummyData) {
+                throw PersistenceError.createCachePersistenceError(
+                    "Persistence check failed. Data was written but it could not be read. " +
+                    "Possible cause: on Linux, LibSecret is installed but D-Bus isn't running \
+                    because it cannot be started over SSH."
+                );
+            }
+
+            if (retrievedDummyData !== Constants.PERSISTENCE_TEST_DATA) {
+                throw PersistenceError.createCachePersistenceError(
+                    `Persistence check failed. Data written ${Constants.PERSISTENCE_TEST_DATA} is different \
+                    from data read ${retrievedDummyData}`
+                );
+            }
+            await persistenceValidator.delete();
+            return true;
+        } catch (e) {
+            throw PersistenceError.createCachePersistenceError(`Verifing persistence failed with the error: ${e}`);
+        }
+    }
+
+}

--- a/src/axios-d365/auth/oauth/msal/extensions/persistence/DataProtectionScope.ts
+++ b/src/axios-d365/auth/oauth/msal/extensions/persistence/DataProtectionScope.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Specifies the scope of the data protection - either the current user or the local
+ * machine.
+ *
+ * You do not need a key to protect or unprotect the data.
+ * If you set the Scope to CurrentUser, only applications running on your credentials can
+ * unprotect the data; however, that means that any application running on your credentials
+ * can access the protected data. If you set the Scope to LocalMachine, any full-trust
+ * application on the computer can unprotect, access, and modify the data.
+ *
+ */
+export enum DataProtectionScope {
+    CurrentUser = "CurrentUser",
+    LocalMachine = "LocalMachine",
+}

--- a/src/axios-d365/auth/oauth/msal/extensions/persistence/FilePersistence.ts
+++ b/src/axios-d365/auth/oauth/msal/extensions/persistence/FilePersistence.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { promises as fs } from "fs";
+import { dirname } from "path";
+import { IPersistence } from "./IPersistence";
+import { Constants } from "../utils/Constants";
+import { PersistenceError } from "../error/PersistenceError";
+import { Logger, LoggerOptions, LogLevel } from "@azure/msal-common";
+import { BasePersistence } from "./BasePersistence";
+
+/**
+ * Reads and writes data to file specified by file location. File contents are not
+ * encrypted.
+ *
+ * If file or directory has not been created, it FilePersistence.create() will create
+ * file and any directories in the path recursively.
+ */
+export class FilePersistence extends BasePersistence implements IPersistence {
+
+    private filePath!: string;
+    private logger!: Logger;
+
+    public static async create(fileLocation: string, loggerOptions?: LoggerOptions): Promise<FilePersistence> {
+        const filePersistence = new FilePersistence();
+        filePersistence.filePath = fileLocation;
+        filePersistence.logger = new Logger(loggerOptions || FilePersistence.createDefaultLoggerOptions());
+        await filePersistence.createCacheFile();
+        return filePersistence;
+    }
+
+    public async save(contents: string): Promise<void> {
+        try {
+            await fs.writeFile(this.getFilePath(), contents, "utf-8");
+        } catch (err: any) {
+            throw PersistenceError.createFileSystemError(err.code, err.message);
+        }
+    }
+
+    public async saveBuffer(contents: Uint8Array): Promise<void> {
+        try {
+            await fs.writeFile(this.getFilePath(), contents);
+        } catch (err: any) {
+            throw PersistenceError.createFileSystemError(err.code, err.message);
+        }
+    }
+
+    public async load(): Promise<string | null> {
+        try {
+            return await fs.readFile(this.getFilePath(), "utf-8");
+        } catch (err: any) {
+            throw PersistenceError.createFileSystemError(err.code, err.message);
+        }
+    }
+
+    public async loadBuffer(): Promise<Uint8Array> {
+        try {
+            return await fs.readFile(this.getFilePath());
+        } catch (err: any) {
+            throw PersistenceError.createFileSystemError(err.code, err.message);
+        }
+    }
+
+    public async delete(): Promise<boolean> {
+        try {
+            await fs.unlink(this.getFilePath());
+            return true;
+        } catch (err: any) {
+            if (err.code === Constants.ENOENT_ERROR) {
+                // file does not exist, so it was not deleted
+                this.logger.warning("Cache file does not exist, so it could not be deleted");
+                return false;
+            }
+            throw PersistenceError.createFileSystemError(err.code, err.message);
+        }
+    }
+
+    public getFilePath(): string {
+        return this.filePath;
+    }
+
+    public async reloadNecessary(lastSync: number): Promise<boolean> {
+        return lastSync < await this.timeLastModified();
+    }
+
+    public getLogger(): Logger {
+        return this.logger;
+    }
+
+    public createForPersistenceValidation(): Promise<FilePersistence> {
+        const testCacheFileLocation = `${dirname(this.filePath)}/test.cache`;
+        return FilePersistence.create(testCacheFileLocation);
+    }
+
+    private static createDefaultLoggerOptions(): LoggerOptions {
+        return {
+            loggerCallback: () => {
+                // allow users to not set loggerCallback
+            },
+            piiLoggingEnabled: false,
+            logLevel: LogLevel.Info
+        };
+    }
+
+    private async timeLastModified(): Promise<number> {
+        try {
+            const stats = await fs.stat(this.filePath);
+            return stats.mtime.getTime();
+        } catch (err: any) {
+            if (err.code === Constants.ENOENT_ERROR) {
+                // file does not exist, so it's never been modified
+                this.logger.verbose("Cache file does not exist");
+                return 0;
+            }
+            throw PersistenceError.createFileSystemError(err.code, err.message);
+        }
+    }
+
+    private async createCacheFile(): Promise<void> {
+        await this.createFileDirectory();
+        // File is created only if it does not exist
+        const fileHandle = await fs.open(this.filePath, "a");
+        await fileHandle.close();
+        this.logger.info(`File created at ${this.filePath}`);
+    }
+
+    private async createFileDirectory(): Promise<void> {
+        try {
+            await fs.mkdir(dirname(this.filePath), {recursive: true});
+        } catch (err: any) {
+            if (err.code === Constants.EEXIST_ERROR) {
+                this.logger.info(`Directory ${dirname(this.filePath)}  already exists`);
+            } else {
+                throw PersistenceError.createFileSystemError(err.code, err.message);
+            }
+        }
+    }
+}

--- a/src/axios-d365/auth/oauth/msal/extensions/persistence/FilePersistenceWithDataProtection.ts
+++ b/src/axios-d365/auth/oauth/msal/extensions/persistence/FilePersistenceWithDataProtection.ts
@@ -6,11 +6,11 @@
 import { IPersistence } from "./IPersistence";
 import { FilePersistence } from "./FilePersistence";
 import { PersistenceError } from "../error/PersistenceError";
-import { Dpapi } from "../Dpapi";
 import { DataProtectionScope } from "./DataProtectionScope";
 import { Logger, LoggerOptions } from "@azure/msal-common";
 import { dirname } from "path";
 import { BasePersistence } from "./BasePersistence";
+import { Dpapi } from "@primno/dpapi";
 
 /**
  * Uses CryptProtectData and CryptUnprotectData on Windows to encrypt and decrypt file contents.

--- a/src/axios-d365/auth/oauth/msal/extensions/persistence/FilePersistenceWithDataProtection.ts
+++ b/src/axios-d365/auth/oauth/msal/extensions/persistence/FilePersistenceWithDataProtection.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IPersistence } from "./IPersistence";
+import { FilePersistence } from "./FilePersistence";
+import { PersistenceError } from "../error/PersistenceError";
+import { Dpapi } from "../Dpapi";
+import { DataProtectionScope } from "./DataProtectionScope";
+import { Logger, LoggerOptions } from "@azure/msal-common";
+import { dirname } from "path";
+import { BasePersistence } from "./BasePersistence";
+
+/**
+ * Uses CryptProtectData and CryptUnprotectData on Windows to encrypt and decrypt file contents.
+ *
+ * scope: Scope of the data protection. Either local user or the current machine
+ * optionalEntropy: Password or other additional entropy used to encrypt the data
+ */
+export class FilePersistenceWithDataProtection extends BasePersistence implements IPersistence {
+
+    private filePersistence!: FilePersistence;
+    private scope: DataProtectionScope;
+    private optionalEntropy!: Uint8Array;
+
+    private constructor(scope: DataProtectionScope, optionalEntropy?: string) {
+        super();
+        this.scope = scope;
+        (this.optionalEntropy as any) = optionalEntropy ? Buffer.from(optionalEntropy, "utf-8") : null;
+    }
+
+    public static async create(
+        fileLocation: string,
+        scope: DataProtectionScope,
+        optionalEntropy?: string,
+        loggerOptions?: LoggerOptions): Promise<FilePersistenceWithDataProtection> {
+
+        const persistence = new FilePersistenceWithDataProtection(scope, optionalEntropy);
+        persistence.filePersistence = await FilePersistence.create(fileLocation, loggerOptions);
+        return persistence;
+    }
+
+    public async save(contents: string): Promise<void> {
+        try {
+            const encryptedContents = Dpapi.protectData(
+                Buffer.from(contents, "utf-8"),
+                this.optionalEntropy,
+                this.scope.toString());
+            await this.filePersistence.saveBuffer(encryptedContents);
+        } catch (err: any) {
+            throw PersistenceError.createFilePersistenceWithDPAPIError(err.message);
+        }
+    }
+
+    public async load(): Promise<string | null> {
+        try {
+            const encryptedContents = await this.filePersistence.loadBuffer();
+            if (typeof encryptedContents === "undefined" || !encryptedContents || 0 === encryptedContents.length) {
+                this.filePersistence.getLogger().info("Encrypted contents loaded from file were null or empty");
+                return null;
+            }
+            return Dpapi.unprotectData(
+                encryptedContents,
+                this.optionalEntropy,
+                this.scope.toString()).toString();
+        } catch (err: any) {
+            throw PersistenceError.createFilePersistenceWithDPAPIError(err.message);
+        }
+    }
+
+    public async delete(): Promise<boolean> {
+        return this.filePersistence.delete();
+    }
+
+    public async reloadNecessary(lastSync: number): Promise<boolean> {
+        return this.filePersistence.reloadNecessary(lastSync);
+    }
+
+    public getFilePath(): string {
+        return this.filePersistence.getFilePath();
+    }
+
+    public getLogger(): Logger {
+        return this.filePersistence.getLogger();
+    }
+
+    public createForPersistenceValidation(): Promise<FilePersistenceWithDataProtection> {
+        const testCacheFileLocation = `${dirname(this.filePersistence.getFilePath())}/test.cache`;
+        return FilePersistenceWithDataProtection.create(testCacheFileLocation, DataProtectionScope.CurrentUser);
+    }
+}

--- a/src/axios-d365/auth/oauth/msal/extensions/persistence/IPersistence.ts
+++ b/src/axios-d365/auth/oauth/msal/extensions/persistence/IPersistence.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Logger } from "@azure/msal-common";
+
+export interface IPersistence {
+    save(contents: string): Promise<void>;
+    load(): Promise<string | null>;
+    delete(): Promise<boolean>;
+    reloadNecessary(lastSync: number): Promise<boolean>;
+    getFilePath(): string;
+    getLogger(): Logger;
+    verifyPersistence(): Promise<boolean>;
+    createForPersistenceValidation(): Promise<IPersistence>;
+}

--- a/src/axios-d365/auth/oauth/msal/extensions/persistence/IPersistenceConfiguration.ts
+++ b/src/axios-d365/auth/oauth/msal/extensions/persistence/IPersistenceConfiguration.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { DataProtectionScope } from "./DataProtectionScope";
+
+export interface IPersistenceConfiguration {
+    cachePath?: string,
+    dataProtectionScope?: DataProtectionScope,
+    serviceName?: string,
+    accountName?: string,
+    usePlaintextFileOnLinux?: boolean,
+}

--- a/src/axios-d365/auth/oauth/msal/extensions/persistence/KeychainPersistence.ts
+++ b/src/axios-d365/auth/oauth/msal/extensions/persistence/KeychainPersistence.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { setPassword, getPassword, deletePassword } from "keytar";
+import { FilePersistence } from "./FilePersistence";
+import { IPersistence } from "./IPersistence";
+import { PersistenceError } from "../error/PersistenceError";
+import { Logger, LoggerOptions } from "@azure/msal-common";
+import { dirname } from "path";
+import { BasePersistence } from "./BasePersistence";
+
+/**
+ * Uses reads and writes passwords to macOS keychain
+ *
+ * serviceName: Identifier used as key for whatever value is stored
+ * accountName: Account under which password should be stored
+ */
+export class KeychainPersistence extends BasePersistence implements IPersistence {
+
+    protected readonly serviceName;
+    protected readonly accountName;
+    private filePersistence!: FilePersistence;
+
+    private constructor(serviceName: string, accountName: string) {
+        super();
+        this.serviceName = serviceName;
+        this.accountName = accountName;
+    }
+
+    public static async create(
+        fileLocation: string,
+        serviceName: string,
+        accountName: string,
+        loggerOptions?: LoggerOptions): Promise<KeychainPersistence> {
+
+        const persistence = new KeychainPersistence(serviceName, accountName);
+        persistence.filePersistence = await FilePersistence.create(fileLocation, loggerOptions);
+        return persistence;
+    }
+
+    public async save(contents: string): Promise<void> {
+        try {
+            await setPassword(this.serviceName, this.accountName, contents);
+        } catch (err: any) {
+            throw PersistenceError.createKeychainPersistenceError(err.message);
+        }
+        // Write dummy data to update file mtime
+        await this.filePersistence.save("{}");
+    }
+
+    public async load(): Promise<string | null> {
+        try{
+            return await getPassword(this.serviceName, this.accountName);
+        } catch(err: any){
+            throw PersistenceError.createKeychainPersistenceError(err.message);
+        }
+    }
+
+    public async delete(): Promise<boolean> {
+        try {
+            await this.filePersistence.delete();
+            return await deletePassword(this.serviceName, this.accountName);
+        } catch (err: any) {
+            throw PersistenceError.createKeychainPersistenceError(err.message);
+        }
+    }
+
+    public async reloadNecessary(lastSync: number): Promise<boolean> {
+        return this.filePersistence.reloadNecessary(lastSync);
+    }
+
+    public getFilePath(): string {
+        return this.filePersistence.getFilePath();
+    }
+
+    public getLogger(): Logger {
+        return this.filePersistence.getLogger();
+    }
+   
+    public createForPersistenceValidation(): Promise<KeychainPersistence> {
+        const testCacheFileLocation = `${dirname(this.filePersistence.getFilePath())}/test.cache`;
+        return KeychainPersistence.create(
+            testCacheFileLocation, 
+            "persistenceValidationServiceName", "persistencValidationAccountName"
+        );
+    }
+}

--- a/src/axios-d365/auth/oauth/msal/extensions/persistence/LibSecretPersistence.ts
+++ b/src/axios-d365/auth/oauth/msal/extensions/persistence/LibSecretPersistence.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { setPassword, getPassword, deletePassword } from "keytar";
+import { FilePersistence } from "./FilePersistence";
+import { IPersistence } from "./IPersistence";
+import { PersistenceError } from "../error/PersistenceError";
+import { Logger, LoggerOptions } from "@azure/msal-common";
+import { dirname } from "path";
+import { BasePersistence } from "./BasePersistence";
+
+/**
+ * Uses reads and writes passwords to Secret Service API/libsecret. Requires libsecret
+ * to be installed.
+ *
+ * serviceName: Identifier used as key for whatever value is stored
+ * accountName: Account under which password should be stored
+ */
+export class LibSecretPersistence extends BasePersistence implements IPersistence {
+
+    protected readonly serviceName;
+    protected readonly accountName;
+    private filePersistence!: FilePersistence;
+
+    private constructor(serviceName: string, accountName: string) {
+        super();
+        this.serviceName = serviceName;
+        this.accountName = accountName;
+    }
+
+    public static async create(
+        fileLocation: string,
+        serviceName: string,
+        accountName: string,
+        loggerOptions?: LoggerOptions): Promise<LibSecretPersistence> {
+
+        const persistence = new LibSecretPersistence(serviceName, accountName);
+        persistence.filePersistence = await FilePersistence.create(fileLocation, loggerOptions);
+        return persistence;
+    }
+
+    public async save(contents: string): Promise<void> {
+        try {
+            await setPassword(this.serviceName, this.accountName, contents);
+        } catch (err: any) {
+            throw PersistenceError.createLibSecretError(err.message);
+        }
+        // Write dummy data to update file mtime
+        await this.filePersistence.save("{}");
+    }
+
+    public async load(): Promise<string | null> {
+        try {
+            return await getPassword(this.serviceName, this.accountName);
+        } catch (err: any) {
+            throw PersistenceError.createLibSecretError(err.message);
+        }
+    }
+
+    public async delete(): Promise<boolean> {
+        try {
+            await this.filePersistence.delete();
+            return await deletePassword(this.serviceName, this.accountName);
+        } catch (err: any) {
+            throw PersistenceError.createLibSecretError(err.message);
+        }
+    }
+
+    public async reloadNecessary(lastSync: number): Promise<boolean> {
+        return this.filePersistence.reloadNecessary(lastSync);
+    }
+
+    public getFilePath(): string {
+        return this.filePersistence.getFilePath();
+    }
+
+    public getLogger(): Logger {
+        return this.filePersistence.getLogger();
+    }
+      
+    public createForPersistenceValidation(): Promise<LibSecretPersistence> {
+        const testCacheFileLocation = `${dirname(this.filePersistence.getFilePath())}/test.cache`;
+        return LibSecretPersistence.create(
+            testCacheFileLocation, 
+            "persistenceValidationServiceName", "persistencValidationAccountName"
+        );
+    }
+}

--- a/src/axios-d365/auth/oauth/msal/extensions/persistence/PersistenceCachePlugin.ts
+++ b/src/axios-d365/auth/oauth/msal/extensions/persistence/PersistenceCachePlugin.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IPersistence } from "./IPersistence";
+import { CrossPlatformLock } from "../lock/CrossPlatformLock";
+import { CrossPlatformLockOptions } from "../lock/CrossPlatformLockOptions";
+import { pid } from "process";
+import { TokenCacheContext, ICachePlugin, Logger } from "@azure/msal-common";
+
+/**
+ * MSAL cache plugin which enables callers to write the MSAL cache to disk on Windows,
+ * macOs, and Linux.
+ *
+ * - Persistence can be one of:
+ * - FilePersistence: Writes and reads from an unencrypted file. Can be used on Windows,
+ * macOs, or Linux.
+ * - FilePersistenceWithDataProtection: Used on Windows, writes and reads from file encrypted
+ * with windows dpapi-addon.
+ * - KeychainPersistence: Used on macOs, writes and reads from keychain.
+ * - LibSecretPersistence: Used on linux, writes and reads from secret service API. Requires
+ * libsecret be installed.
+ */
+export class PersistenceCachePlugin implements ICachePlugin {
+
+    public persistence: IPersistence;
+    public lastSync: number;
+    public currentCache: string | null;
+    public lockFilePath: string;
+
+    private crossPlatformLock: CrossPlatformLock;
+
+    private logger: Logger;
+
+    constructor(persistence: IPersistence, lockOptions?: CrossPlatformLockOptions) {
+        this.persistence = persistence;
+
+        // initialize logger
+        this.logger = persistence.getLogger();
+
+        // create file lock
+        this.lockFilePath = `${this.persistence.getFilePath()}.lockfile`;
+        this.crossPlatformLock = new CrossPlatformLock(this.lockFilePath, this.logger, lockOptions);
+
+        // initialize default values
+        this.lastSync = 0;
+        this.currentCache = null;
+    }
+
+    /**
+     * Reads from storage and saves an in-memory copy. If persistence has not been updated
+     * since last time data was read, in memory copy is used.
+     *
+     * If cacheContext.cacheHasChanged === true, then file lock is created and not deleted until
+     * afterCacheAccess() is called, to prevent the cache file from changing in between
+     * beforeCacheAccess() and afterCacheAccess().
+     */
+    public async beforeCacheAccess(cacheContext: TokenCacheContext): Promise<void> {
+        this.logger.info("Executing before cache access");
+        const reloadNecessary = await this.persistence.reloadNecessary(this.lastSync);
+        if (!reloadNecessary && this.currentCache !== null) {
+            if (cacheContext.cacheHasChanged) {
+                this.logger.verbose("Cache context has changed");
+                await this.crossPlatformLock.lock();
+            }
+            return;
+        }
+        try {
+            this.logger.info(`Reload necessary. Last sync time: ${this.lastSync}`);
+            await this.crossPlatformLock.lock();
+
+            this.currentCache = await this.persistence.load();
+            this.lastSync = new Date().getTime();
+            cacheContext.tokenCache.deserialize(this.currentCache as string);
+
+            this.logger.info(`Last sync time updated to: ${this.lastSync}`);
+        } finally {
+            if (!cacheContext.cacheHasChanged) {
+                await this.crossPlatformLock.unlock();
+                this.logger.info(`Pid ${pid} released lock`);
+            } else {
+                this.logger.info(`Pid ${pid} beforeCacheAccess did not release lock`);
+            }
+        }
+    }
+
+    /**
+     * Writes to storage if MSAL in memory copy of cache has been changed.
+     */
+    public async afterCacheAccess(cacheContext: TokenCacheContext): Promise<void> {
+        this.logger.info("Executing after cache access");
+        try {
+            if (cacheContext.cacheHasChanged) {
+                this.logger.info("Msal in-memory cache has changed. Writing changes to persistence");
+                this.currentCache = cacheContext.tokenCache.serialize();
+                await this.persistence.save(this.currentCache);
+            } else {
+                this.logger.info("Msal in-memory cache has not changed. Did not write to persistence");
+            }
+        } finally {
+            await this.crossPlatformLock.unlock();
+            this.logger.info(`Pid ${pid} afterCacheAccess released lock`);
+        }
+    }
+}

--- a/src/axios-d365/auth/oauth/msal/extensions/persistence/PersistenceCreator.ts
+++ b/src/axios-d365/auth/oauth/msal/extensions/persistence/PersistenceCreator.ts
@@ -7,12 +7,13 @@
 //import { FilePersistenceWithDataProtection } from "./FilePersistenceWithDataProtection";
 import { LibSecretPersistence } from "./LibSecretPersistence";
 import { KeychainPersistence } from "./KeychainPersistence";
-//import { DataProtectionScope } from "./DataProtectionScope";
+import { DataProtectionScope } from "./DataProtectionScope";
 import { Environment } from "../utils/Environment";
 import { IPersistence } from "./IPersistence";
 import { FilePersistence } from "./FilePersistence";
 import { PersistenceError } from "../error/PersistenceError";
 import { IPersistenceConfiguration } from "./IPersistenceConfiguration";
+import { FilePersistenceWithDataProtection } from "./FilePersistenceWithDataProtection";
 
 export class PersistenceCreator {
     static async createPersistence(config: IPersistenceConfiguration): Promise<IPersistence> {
@@ -20,17 +21,12 @@ export class PersistenceCreator {
 
         // On Windows, uses a DPAPI encrypted file
         if (Environment.isWindowsPlatform()) {
-            // if (!config.cachePath || !config.dataProtectionScope) {
-            //     throw PersistenceError.createPersistenceNotValidatedError(
-            //         "Cache path and/or data protection scope not provided for the FilePersistenceWithDataProtection cache plugin");
-            // }
-
-            if (!config.cachePath || !config.serviceName || !config.accountName) {
+            if (!config.cachePath || !config.dataProtectionScope) {
                 throw PersistenceError.createPersistenceNotValidatedError(
-                    "Cache path, service name and/or account name not provided for the KeychainPersistence cache plugin");
+                    "Cache path and/or data protection scope not provided for the FilePersistenceWithDataProtection cache plugin");
             }
 
-            peristence = await KeychainPersistence.create(config.cachePath, config.serviceName, config.accountName);
+            peristence = await FilePersistenceWithDataProtection.create(config.cachePath, DataProtectionScope.CurrentUser);
         }
 
         // On Mac, uses keychain.

--- a/src/axios-d365/auth/oauth/msal/extensions/persistence/PersistenceCreator.ts
+++ b/src/axios-d365/auth/oauth/msal/extensions/persistence/PersistenceCreator.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ * @licence
+ */
+
+//import { FilePersistenceWithDataProtection } from "./FilePersistenceWithDataProtection";
+import { LibSecretPersistence } from "./LibSecretPersistence";
+import { KeychainPersistence } from "./KeychainPersistence";
+//import { DataProtectionScope } from "./DataProtectionScope";
+import { Environment } from "../utils/Environment";
+import { IPersistence } from "./IPersistence";
+import { FilePersistence } from "./FilePersistence";
+import { PersistenceError } from "../error/PersistenceError";
+import { IPersistenceConfiguration } from "./IPersistenceConfiguration";
+
+export class PersistenceCreator {
+    static async createPersistence(config: IPersistenceConfiguration): Promise<IPersistence> {
+        let peristence: IPersistence;
+
+        // On Windows, uses a DPAPI encrypted file
+        if (Environment.isWindowsPlatform()) {
+            // if (!config.cachePath || !config.dataProtectionScope) {
+            //     throw PersistenceError.createPersistenceNotValidatedError(
+            //         "Cache path and/or data protection scope not provided for the FilePersistenceWithDataProtection cache plugin");
+            // }
+
+            if (!config.cachePath || !config.serviceName || !config.accountName) {
+                throw PersistenceError.createPersistenceNotValidatedError(
+                    "Cache path, service name and/or account name not provided for the KeychainPersistence cache plugin");
+            }
+
+            peristence = await KeychainPersistence.create(config.cachePath, config.serviceName, config.accountName);
+        }
+
+        // On Mac, uses keychain.
+        else if (Environment.isMacPlatform()) {
+            if (!config.cachePath || !config.serviceName || !config.accountName) {
+                throw PersistenceError.createPersistenceNotValidatedError(
+                    "Cache path, service name and/or account name not provided for the KeychainPersistence cache plugin");
+            }
+
+            peristence = await KeychainPersistence.create(config.cachePath, config.serviceName, config.accountName);
+        }
+
+        // On Linux, uses  libsecret to store to secret service. Libsecret has to be installed.
+        else if (Environment.isLinuxPlatform()) {
+            if (!config.cachePath || !config.serviceName || !config.accountName) {
+                throw PersistenceError.createPersistenceNotValidatedError(
+                    "Cache path, service name and/or account name not provided for the LibSecretPersistence cache plugin");
+            }
+
+            peristence = await LibSecretPersistence.create(config.cachePath, config.serviceName, config.accountName);
+        }
+
+        else {
+            throw PersistenceError.createNotSupportedError(
+                "The current environment is not supported by msal-node-extensions yet.");
+        }
+
+        // Initially suppress the error thrown during persistence verification to allow us to fallback to plain text
+        const isPersistenceVerified = await peristence.verifyPersistence().catch(() => false);
+        
+        if (!isPersistenceVerified) {
+            if (Environment.isLinuxPlatform() && config.usePlaintextFileOnLinux) {
+                if (!config.cachePath) {
+                    throw PersistenceError.createPersistenceNotValidatedError(
+                        "Cache path not provided for the FilePersistence cache plugin");
+                }
+
+                peristence = await FilePersistence.create(config.cachePath);
+
+                const isFilePersistenceVerified = await peristence.verifyPersistence();
+                if (isFilePersistenceVerified) {
+                    return peristence;
+                }
+            }
+
+            throw PersistenceError.createPersistenceNotVerifiedError("Persistence could not be verified");
+        }
+
+        return peristence;
+    }
+}

--- a/src/axios-d365/auth/oauth/msal/extensions/utils/Constants.ts
+++ b/src/axios-d365/auth/oauth/msal/extensions/utils/Constants.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export const Constants = {
+
+    /**
+     * An existing file was the target of an operation that required that the target not exist
+     */
+    EEXIST_ERROR: "EEXIST",
+
+    /**
+     * No such file or directory: Commonly raised by fs operations to indicate that a component
+     * of the specified pathname does not exist. No entity (file or directory) could be found
+     * by the given path
+     */
+    ENOENT_ERROR: "ENOENT",
+
+    /**
+     * Operation not permitted. An attempt was made to perform an operation that requires 
+     * elevated privileges. 
+     */
+    EPERM_ERROR: "EPERM",
+    
+    /**
+     * Default service name for using MSAL Keytar
+     */
+    DEFAULT_SERVICE_NAME: "msal-node-extensions",
+
+    /**
+     * Test data used to verify underlying persistence mechanism
+     */
+    PERSISTENCE_TEST_DATA: "Dummy data to verify underlying persistence mechanism",
+
+    /**
+     * This is the value of a the guid if the process is being ran by the root user
+     */
+    LINUX_ROOT_USER_GUID: 0,
+
+    /**
+     * List of environment variables
+     */
+    ENVIRONMENT: {
+        HOME: "HOME",
+        LOGNAME: "LOGNAME",
+        USER: "USER",
+        LNAME: "LNAME",
+        USERNAME: "USERNAME",
+        PLATFORM: "platform",
+        LOCAL_APPLICATION_DATA: "LOCALAPPDATA"
+    },
+
+    // Name of the default cache file
+    DEFAULT_CACHE_FILE_NAME: "cache.json"
+};
+
+export enum Platform {
+    WINDOWS = "win32",
+    LINUX = "linux",
+    MACOS = "darwin"
+}

--- a/src/axios-d365/auth/oauth/msal/extensions/utils/Environment.ts
+++ b/src/axios-d365/auth/oauth/msal/extensions/utils/Environment.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import path from "path";
+import { Constants, Platform } from "./Constants";
+import { PersistenceError } from "../error/PersistenceError";
+import { StringUtils } from "@azure/msal-common";
+
+export class Environment {
+    static get homeEnvVar(): string {
+        return this.getEnvironmentVariable(Constants.ENVIRONMENT.HOME);
+    }
+    
+    static get lognameEnvVar(): string {
+        return this.getEnvironmentVariable(Constants.ENVIRONMENT.LOGNAME);
+    }
+
+    static get userEnvVar(): string {
+        return this.getEnvironmentVariable(Constants.ENVIRONMENT.USER);
+    }
+
+    static get lnameEnvVar(): string {
+        return this.getEnvironmentVariable(Constants.ENVIRONMENT.LNAME);
+    }
+
+    static get usernameEnvVar(): string {
+        return this.getEnvironmentVariable(Constants.ENVIRONMENT.USERNAME);
+    }
+
+    static getEnvironmentVariable(name: string): string {
+        return process.env[name] as string;
+    }
+
+    static getEnvironmentPlatform(): string {
+        return process.platform;
+    }
+
+    static isWindowsPlatform(): boolean {
+        return this.getEnvironmentPlatform() === Platform.WINDOWS;
+    }
+
+    static isLinuxPlatform(): boolean {
+        return this.getEnvironmentPlatform() === Platform.LINUX;
+    }
+
+    static isMacPlatform(): boolean {
+        return this.getEnvironmentPlatform() === Platform.MACOS;
+    }
+
+    static isLinuxRootUser(): boolean {
+        if (!process.getuid) {
+            return false;
+        }
+        return process.getuid() === Constants.LINUX_ROOT_USER_GUID;
+    }
+
+    static getUserRootDirectory(): string {
+        return !this.isWindowsPlatform ?
+            this.getUserHomeDirOnUnix() as string :
+            this.getUserHomeDirOnWindows();
+    }
+
+    static getUserHomeDirOnWindows(): string {
+        return this.getEnvironmentVariable(Constants.ENVIRONMENT.LOCAL_APPLICATION_DATA);
+    }
+
+    static getUserHomeDirOnUnix(): string | null {
+        if (this.isWindowsPlatform()) {
+            throw PersistenceError.createNotSupportedError(
+                "Getting the user home directory for unix is not supported in windows");
+        }
+
+        if (!StringUtils.isEmpty(this.homeEnvVar)) {
+            return this.homeEnvVar;
+        }
+
+        let username = null;
+        if (!StringUtils.isEmpty(this.lognameEnvVar)) {
+            username = this.lognameEnvVar;
+        } else if (!StringUtils.isEmpty(this.userEnvVar)) {
+            username = this.userEnvVar;
+        } else if (!StringUtils.isEmpty(this.lnameEnvVar)) {
+            username = this.lnameEnvVar;
+        } else if (!StringUtils.isEmpty(this.usernameEnvVar)) {
+            username = this.usernameEnvVar;
+        }
+
+        if (this.isMacPlatform()) {
+            return !StringUtils.isEmpty(username as string) ? path.join("/Users", username as string) : null;
+        } else if (this.isLinuxPlatform()) {
+            if (this.isLinuxRootUser()) {
+                return "/root";
+            } else {
+                return !StringUtils.isEmpty(username as string) ? path.join("/home", username as string) : null;
+            }
+        } else {
+            throw PersistenceError.createNotSupportedError(
+                "Getting the user home directory for unix is not supported in windows");
+        }
+
+    }
+}

--- a/src/axios-d365/axios.ts
+++ b/src/axios-d365/axios.ts
@@ -17,7 +17,7 @@ export async function createAxiosClient(connectionString: string, options: D365C
 
     switch (connectionStringProcessor.authType) {
         case AuthenticationType.AD:     return createNtlmClient(connectionStringProcessor, axiosConfig);
-        case AuthenticationType.OAuth:  return await createOAuthClient(connectionStringProcessor, axiosConfig, options.cacheDirectory);
+        case AuthenticationType.OAuth:  return await createOAuthClient(connectionStringProcessor, axiosConfig, options.persistence!);
 
         default: return axios.create(axiosConfig);
     }

--- a/src/d365-client.ts
+++ b/src/d365-client.ts
@@ -1,6 +1,6 @@
-import { Environment } from "@azure/msal-node-extensions";
-import { AxiosInstance, Method, AxiosResponse, AxiosError } from "axios";
+import { AxiosInstance, Method, AxiosResponse } from "axios";
 import { createAxiosClient } from "./axios-d365";
+import { Environment } from "./axios-d365/auth/oauth/msal/extensions";
 import { isNullOrUndefined } from "./common";
 import { convertQueryOptionsToString, MultipleQueryOptions, QueryOptions } from "./query-options";
 
@@ -9,8 +9,33 @@ export interface ErrorResponse {
     message: string;
 }
 
+export interface PersistenceOptions {
+    /**
+     * Enable persistence. Default: false.
+     */
+    enabled?: boolean;
+    /**
+     * Cache directory. Default: user root dir.
+     */
+     cacheDirectory?: string;
+     /**
+      * Service name. Default: d365-client
+      */
+     serviceName?: string;
+     /**
+      * Account name. Default: d365-client
+      */
+     accountName?: string;
+}
+
+/**
+ * Configuration of D365-Client.
+ */
 export interface D365ClientOptions {
-    cacheDirectory: string;
+    /**
+     * Configuration of persistence cache.
+     */
+    persistence?: PersistenceOptions;
 }
 
 interface RequestOptions {
@@ -41,7 +66,13 @@ export class D365Client {
 
     public constructor(connectionString: string, options?: D365ClientOptions) {
         this.options = {
-            cacheDirectory: options?.cacheDirectory ?? Environment.getUserRootDirectory()
+            persistence: {
+                enabled: false,
+                accountName: "d365-client",
+                serviceName: "d365-client",
+                cacheDirectory: Environment.getUserRootDirectory(),
+                ...options?.persistence 
+            }
         };
         this.axiosClient = createAxiosClient(connectionString, this.options);
     }


### PR DESCRIPTION
@azure/msal-node-extension does not provide pre-built DPAPI. Visual C++ and Python are required during installation.
See: https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/3332

- [X] Remove depencency to @msal-node-extension
- [X] Use [@primno/dpapi](https://github.com/primno/dpapi) which provides a pre-built version of DPAPI.