### PR TITLE
feat(dataverse-auth): Set default client id

### DIFF
--- a/.changeset/dull-pants-thank.md
+++ b/.changeset/dull-pants-thank.md
@@ -1,0 +1,5 @@
+---
+"@primno/dataverse-auth": patch
+---
+
+The default client id for OAuth2 becomes Sample Client Id (51f81489-12ee-4a9e-aaae-a2591f45987d)

--- a/packages/dataverse-auth/README.md
+++ b/packages/dataverse-auth/README.md
@@ -17,7 +17,7 @@
 - [Persistent token cache](#token-cache-persistence) to avoid re-authenticating.
 - [Authority discovery](#discover-authority)
 
-Works with [`@primno/dataverse-client`](https://www.npmjs.com/package/@primno/dataverse-client) to make requests to Dataverse / Dynamics 365 CE, but can be used alone, as a **standalone library**.
+Works with [`@primno/dataverse-client`](https://www.npmjs.com/package/@primno/dataverse-client) to make requests to Dataverse / Dynamics 365 CE, but can be used as a **standalone library**.
 
 > This package is part of the [Primno](https://primno.io) framework.
 

--- a/packages/dataverse-auth/README.md
+++ b/packages/dataverse-auth/README.md
@@ -166,9 +166,10 @@ interface OAuthConfig {
          */
         grantType: "client_credential" | "password" | "device_code";
         /**
-         * Client ID
+         * Client ID.
+         * @default "51f81489-12ee-4a9e-aaae-a2591f45987d" (Sample client id)
          */
-        clientId: string;
+        clientId?: string;
         /**
          * Client secret for ConfidentialClientApplication.
          * If set, clientCertificate is not required.

--- a/packages/dataverse-auth/package.json
+++ b/packages/dataverse-auth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@primno/dataverse-auth",
   "version": "0.6.0",
-  "description": "Authenticate to Dataverse and Dynamics 365 with connection string or OAuth 2.0. Provides a token persistence cache.",
+  "description": "Authenticate to Dataverse and Dynamics 365 with a connection string or OAuth 2.0. Provides a token persistence cache.",
   "repository": "github:primno/dataverse",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/packages/dataverse-auth/src/oauth/msal/token/application.ts
+++ b/packages/dataverse-auth/src/oauth/msal/token/application.ts
@@ -1,4 +1,4 @@
-import { ConfidentialClientApplication, IConfidentialClientApplication, IPublicClientApplication, LogLevel, PublicClientApplication } from "@azure/msal-node";
+import { ConfidentialClientApplication, Configuration, IConfidentialClientApplication, IPublicClientApplication, LogLevel, PublicClientApplication } from "@azure/msal-node";
 import { OAuthConfig } from "../../oauth-configuration";
 import { AxiosNetworkModule } from "../axios-network-module";
 import { getCacheOptions } from "./cache";
@@ -18,9 +18,9 @@ export type Application = PublicApplication | ConfidentialApplication;
 export async function createApplication(oAuthOptions: OAuthConfig): Promise<Application> {
     const { credentials, persistence } = oAuthOptions;
 
-    const options = {
+    const options: Configuration = {
         auth: {
-            clientId: credentials.clientId,
+            clientId: credentials.clientId ?? "51f81489-12ee-4a9e-aaae-a2591f45987d",
             authority: credentials.authorityUrl,
             knownAuthorities: [credentials.authorityUrl]
         },

--- a/packages/dataverse-auth/src/oauth/oauth-configuration.ts
+++ b/packages/dataverse-auth/src/oauth/oauth-configuration.ts
@@ -7,9 +7,10 @@ export interface OAuthCredentials {
      */
     grantType: "client_credential" | "password" | "device_code";
     /**
-     * Client ID
+     * Client ID.
+     * @default: "51f81489-12ee-4a9e-aaae-a2591f45987d" (Sample client id)
      */
-    clientId: string;
+    clientId?: string;
     /**
      * Client secret for ConfidentialClientApplication.
      * If set, clientCertificate is not required.


### PR DESCRIPTION
The default client id for OAuth2 becomes Sample Client Id (51f81489-12ee-4a9e-aaae-a2591f45987d).